### PR TITLE
Support for sorting and disabling proof services

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,6 @@
 Protege Proof-Based Explanation
 
-Protege Proof-Based Explanation is Copyright (c) 2014 - 2021 
+Protege Proof-Based Explanation is Copyright (c) 2014 - 2022 
 Live Ontologies Project
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ https://github.com/liveontologies/protege-proof-explanation
 
 REQUIREMENTS:
 
-Protege Proof-Based Explanation is tested to work with Protege 5.5.0. It may work 
+Protege Proof-Based Explanation is tested to work with Protege 5.6.0-beta-1-SNAPSHOT. It may work 
 with other versions of Protege.
 
 INSTALLATION:

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@ is displaying, navigating, and updating those proofs in the user interface.
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<protege.version>5.5.0</protege.version>
+		<protege.version>5.6.0-beta-1-SNAPSHOT</protege.version>
 		<owlapi.version>4.5.7</owlapi.version>
 		<pluginId>${project.groupId}.protege.explanation.proof</pluginId>
 		<extensionId>${pluginId}.service</extensionId>

--- a/src/main/java/org/liveontologies/protege/explanation/proof/ProofBasedExplanationResult.java
+++ b/src/main/java/org/liveontologies/protege/explanation/proof/ProofBasedExplanationResult.java
@@ -34,8 +34,10 @@ import javax.swing.SwingUtilities;
 
 import org.liveontologies.protege.explanation.proof.list.ProofFrame;
 import org.liveontologies.protege.explanation.proof.list.ProofFrameList;
+import org.liveontologies.protege.explanation.proof.preferences.ProofBasedExplPrefs;
 import org.liveontologies.protege.explanation.proof.service.ProofService;
 import org.protege.editor.owl.OWLEditorKit;
+import org.protege.editor.owl.ui.explanation.ExplanationPreferences;
 import org.protege.editor.owl.ui.explanation.ExplanationResult;
 import org.semanticweb.owlapi.model.OWLAxiom;
 
@@ -113,15 +115,30 @@ public class ProofBasedExplanationResult extends ExplanationResult
 				.toArray(new ProofService[proofServices.size()]);
 		final JComboBox<ProofService> selector = new JComboBox<ProofService>(
 				services);
+		final ProofBasedExplPrefs prefs = ProofBasedExplPrefs.create().load();
 		if (services.length > 0) {
-			selector.setSelectedItem(services[0]);
-			proofManager_.selectService(services[0]);
+			ProofService selected = services[0];
+			if (ExplanationPreferences.create().load().useLastExplanationService) {
+				String id = prefs.defaultProofService;
+				if (id != null) {
+					for (ProofService s : proofServices) {
+						if (id.equals(s.getPluginId())) {
+							selected = s;
+						}
+					}
+				}
+			}
+			selector.setSelectedItem(selected);
+			proofManager_.selectService(selected);
 		}
 		selector.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				proofManager_.selectService(
-						(ProofService) selector.getSelectedItem());
+				ProofService selected = (ProofService) selector.getSelectedItem();
+				prefs.load();
+				prefs.defaultProofService = selected.getPluginId();
+				prefs.save();
+				proofManager_.selectService(selected);
 			}
 		});
 		return selector;

--- a/src/main/java/org/liveontologies/protege/explanation/proof/ProofBasedExplanationService.java
+++ b/src/main/java/org/liveontologies/protege/explanation/proof/ProofBasedExplanationService.java
@@ -56,7 +56,7 @@ public class ProofBasedExplanationService extends ExplanationService {
 
 	@Override
 	public boolean hasExplanation(OWLAxiom axiom) {
-		for (ProofService service : proofServiceMan_.getProofServices()) {
+		for (ProofService service : proofServiceMan_.getEnabledProofServices()) {
 			if (service.hasProof(axiom)) {
 				return true;
 			}

--- a/src/main/java/org/liveontologies/protege/explanation/proof/ProofManager.java
+++ b/src/main/java/org/liveontologies/protege/explanation/proof/ProofManager.java
@@ -241,7 +241,7 @@ public class ProofManager implements ImportsClosureRecord.ChangeListener,
 	 */
 	public Collection<ProofService> getServices() {
 		List<ProofService> result = new ArrayList<ProofService>();
-		for (ProofService service : proofServiceMan_.getProofServices()) {
+		for (ProofService service : proofServiceMan_.getEnabledProofServices()) {
 			if (service.hasProof(entailment_)) {
 				result.add(service);
 			}

--- a/src/main/java/org/liveontologies/protege/explanation/proof/preferences/ProofBasedExplPrefs.java
+++ b/src/main/java/org/liveontologies/protege/explanation/proof/preferences/ProofBasedExplPrefs.java
@@ -1,5 +1,8 @@
 package org.liveontologies.protege.explanation.proof.preferences;
 
+import java.util.Collections;
+import java.util.List;
+
 /*-
  * #%L
  * Protege Proof-Based Explanation
@@ -30,7 +33,10 @@ public class ProofBasedExplPrefs {
 	private static final String PREFS_KEY_ = "PROOF_BASED_EXPLANATION_PREFS",
 			RECURSIVE_EXPANSION_LIMIT_KEY_ = "RECURSIVE_EXPANSION_LIMIT",
 			DISPLAYED_INFERENCES_PER_CONCLUSION_LIMIT_KEY = "DISPLAYED_INFERENCES_PER_CONCLUSION_LIMIT",
-			REMOVE_UNNECESSARY_INFERENCES_KEY = "REMOVE_UNNECESSARY_INFERENCES";
+			REMOVE_UNNECESSARY_INFERENCES_KEY = "REMOVE_UNNECESSARY_INFERENCES",
+			DEFAULT_PROOF_SERVICE_ID_KEY_ = "DEFAULT_PROOF_SERVICE",
+			PROOF_SERVICES_LIST_KEY_ = "EXPLANATION_SERVICES_LIST",
+			DISABLED_PROOF_SERVICES_KEY_ = "DISABLED_EXPLANATION_SERVICES";
 
 	public final static String RECURSIVE_EXPANSION_LIMIT_DESCRIPTION = "The maximal number of inferences expanded upon long press or alt + click",
 			DISPLAYED_INFERENCES_PER_CONCLUSION_LIMIT_DESCRIPTION = "The maximal number of inferences displayed at once for each conclusion",
@@ -42,6 +48,12 @@ public class ProofBasedExplPrefs {
 	private final static int DEFAULT_DISPLAYED_INFERENCES_PER_CONCLUSION_LIMIT_ = 5;
 
 	private final static boolean DEFAULT_REMOVE_UNNECESSARY_INFERENCES_ = true;
+
+	private final static String DEFAULT_DEFAULT_PROOF_SERVICE_ID_ = null;
+	
+	private final static List<String> DEFAULT_PROOF_SERVICES_LIST_ = Collections.emptyList();
+	
+	private final static List<String> DEFAULT_DISABLED_PROOF_SERVICES_ = Collections.emptyList();
 
 	/**
 	 * {@value #RECURSIVE_EXPANSION_LIMIT_DESCRIPTION}
@@ -57,6 +69,21 @@ public class ProofBasedExplPrefs {
 	 * {@value #REMOVE_UNNECESSARY_INFERENCES_DESCRIPTION}
 	 */
 	public boolean removeUnnecessaryInferences = DEFAULT_REMOVE_UNNECESSARY_INFERENCES_;
+	
+	/**
+	 * The most recently used proof service
+	 */
+	public String defaultProofService = DEFAULT_DEFAULT_PROOF_SERVICE_ID_;
+	
+	/**
+	 * User-sorted list of all loaded proof services
+	 */
+	public List<String> proofServicesList =  DEFAULT_PROOF_SERVICES_LIST_;
+	
+	/**
+	 * List of all disabled proof services
+	 */
+	public List<String> disabledProofServices = DEFAULT_DISABLED_PROOF_SERVICES_;
 
 	private ProofBasedExplPrefs() {
 
@@ -85,6 +112,15 @@ public class ProofBasedExplPrefs {
 		removeUnnecessaryInferences = prefs.getBoolean(
 				REMOVE_UNNECESSARY_INFERENCES_KEY,
 				DEFAULT_REMOVE_UNNECESSARY_INFERENCES_);
+		defaultProofService = prefs.getString(
+				DEFAULT_PROOF_SERVICE_ID_KEY_,
+				DEFAULT_DEFAULT_PROOF_SERVICE_ID_);
+		proofServicesList = prefs.getStringList(
+				PROOF_SERVICES_LIST_KEY_,
+				DEFAULT_PROOF_SERVICES_LIST_);
+		disabledProofServices = prefs.getStringList(
+				DISABLED_PROOF_SERVICES_KEY_,
+				DEFAULT_DISABLED_PROOF_SERVICES_);
 		return this;
 	}
 
@@ -95,6 +131,9 @@ public class ProofBasedExplPrefs {
 				displayedInferencesPerConclusionLimit);
 		prefs.putBoolean(REMOVE_UNNECESSARY_INFERENCES_KEY,
 				removeUnnecessaryInferences);
+		prefs.putString(DEFAULT_PROOF_SERVICE_ID_KEY_, defaultProofService);
+		prefs.putStringList(PROOF_SERVICES_LIST_KEY_, proofServicesList);
+		prefs.putStringList(DISABLED_PROOF_SERVICES_KEY_, disabledProofServices);
 		return this;
 	}
 
@@ -102,6 +141,9 @@ public class ProofBasedExplPrefs {
 		recursiveExpansionLimit = DEFAULT_RECURSIVE_EXPANSION_LIMIT_;
 		displayedInferencesPerConclusionLimit = DEFAULT_DISPLAYED_INFERENCES_PER_CONCLUSION_LIMIT_;
 		removeUnnecessaryInferences = DEFAULT_REMOVE_UNNECESSARY_INFERENCES_;
+		defaultProofService = DEFAULT_DEFAULT_PROOF_SERVICE_ID_;
+		proofServicesList = DEFAULT_PROOF_SERVICES_LIST_;
+		disabledProofServices = DEFAULT_DISABLED_PROOF_SERVICES_;
 		return this;
 	}
 

--- a/src/main/java/org/liveontologies/protege/explanation/proof/preferences/ProofBasedExplanationPreferencesGeneralPanel.java
+++ b/src/main/java/org/liveontologies/protege/explanation/proof/preferences/ProofBasedExplanationPreferencesGeneralPanel.java
@@ -75,7 +75,11 @@ public class ProofBasedExplanationPreferencesGeneralPanel extends OWLPreferences
 
 	@Override
 	public void dispose() throws Exception {
-		// no op
+		try {
+			ProofServiceManager.get(getOWLEditorKit()).reload();
+		} catch (Exception e) {
+			logger.error("An error occurred while reloading proof service plugins.", e);
+		}
 	}
 
 	@Override
@@ -84,11 +88,6 @@ public class ProofBasedExplanationPreferencesGeneralPanel extends OWLPreferences
 				.create();
 		saveTo(prefs);
 		prefs.save();
-		try {
-			ProofServiceManager.get(getOWLEditorKit()).reload();
-		} catch (Exception e) {
-			logger.error("An error occurred while reloading proof service plugins.", e);
-		}
 	}
 
 	private void loadFrom(ProofBasedExplPrefs prefs) {


### PR DESCRIPTION
This addresses #2, but depends on protegeproject/protege#1059 since it uses a configuration option from the general explanation preferences (and also reuses the utility class `SortedPluginsTableModel`).

![Bildschirmfoto 2022-06-16 um 14 36 04](https://user-images.githubusercontent.com/8749392/174071046-05299957-5f40-40f3-9f6a-df543991d6cb.png)

I tested this with the proof services from https://github.com/liveontologies/elk-reasoner and https://github.com/de-tu-dresden-inf-lat/evee.
